### PR TITLE
Fix CoreAudio DLL path not being found (on newer Wine?)

### DIFF
--- a/components/encoder/coreaudioconnect/connector/Makefile
+++ b/components/encoder/coreaudioconnect/connector/Makefile
@@ -17,7 +17,7 @@ OBJECTS	= dllinterface.o main.o
 BINARY	= $(BOCA_PATH)/$(BINDIR)/boca_$(TYPE)_$(TARGET)$(X64).$(VERSION)$(EXECUTABLE)
 
 DEFINE	= -DUNICODE
-LIBS	= -lole32 -lshell32
+LIBS	= -lole32 -lshell32 -lshlwapi
 
 CCOPTS	= -Wno-multichar -I"$(SRCDIR)"/$(BOCA_PATH)/include -I"$(SRCDIR)"/$(BOCA_PATH)/include/support/apple $(DEFINE)
 LDOPTS	= -L $(BOCA_PATH)/$(LIBDIR) $(LIBS)


### PR DESCRIPTION
[FindFirstFile](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea) considers a path with a trailing backslash as invalid:

> This parameter should not be NULL, an invalid string (for example, an empty string or a string that is missing the terminating null character), or end in a trailing backslash (\).

It seems the trailing backslash used to be fine on older versions of Wine, but it has since been fixed.

This could be resolved by trimming the backslash, but I think it's better to use [PathFileExists](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathfileexistsa) instead, which "Determines whether a path to a file system object such as a file or folder is valid.".

I have not tested the changes on Windows, however (but if the Microsoft Documentation is to be believed then it shouldn't have worked before).