### PR TITLE
Replace Illegal Character with Full-Width Ones, if Allow Unicode is true

### DIFF
--- a/runtime/common/utilities.cpp
+++ b/runtime/common/utilities.cpp
@@ -198,17 +198,17 @@ String BoCA::Utilities::ReplaceIncompatibleCharacters(const String &string, Bool
 
 		/* Replace other characters.
 		 */
-		if	(character == '\"')		     { result[p] = '\''; result[++p] = '\''; }
+		if	(character == '\"')		     { result[p] = useUnicode ? L'＂' : '\''; if (!useUnicode) result[++p] = '\''; }
 		else if (character == '\n')		       p--;
 		else if (character == '\r')		       p--;
-		else if (character == '?')		       p--;
-		else if (character == '|')		       result[p] = '_';
-		else if (character == '*')		       p--;
-		else if (character == '<')		       result[p] = '(';
-		else if (character == '>')		       result[p] = ')';
-		else if (character == ':')		       p--;
-		else if (character == '/'  &&  replaceSlashes) result[p] = '-';
-		else if (character == '\\' &&  replaceSlashes) result[p] = '-';
+		else if (character == '?')		       result[p] = useUnicode ? L'？' : p--;
+		else if (character == '|')		       result[p] = useUnicode ? L'｜' : '_';
+		else if (character == '*')		       result[p] = useUnicode ? L'＊' : p--;
+		else if (character == '<')		       result[p] = useUnicode ? L'＜' : '(';
+		else if (character == '>')		       result[p] = useUnicode ? L'＞' : ')';
+		else if (character == ':')		       result[p] = useUnicode ? L'：' : p--;
+		else if (character == '/'  &&  replaceSlashes) result[p] = useUnicode ? L'／' : '-';
+		else if (character == '\\' &&  replaceSlashes) result[p] = useUnicode ? L'＼' : '-';
 		else if (character == ' '  &&  replaceSpaces)  result[p] = '_';
 		else if (character == '\t' &&  replaceSpaces)  result[p] = '_';
 		else if (character == '\t')		       result[p] = ' ';


### PR DESCRIPTION
fixes an issue I openend in freac a few years ago

basically replaces all the illegal characters with their full-width alternatives, if allow unicode characters is enabled, and follows the old behaviour if it isn't enabled