### PR TITLE
Parse REM DISCNUMBER in cue sheets

### DIFF
--- a/components/decoder/cuesheet/cuesheet.cpp
+++ b/components/decoder/cuesheet/cuesheet.cpp
@@ -175,6 +175,15 @@ Error BoCA::DecoderCueSheet::GetStreamInfo(const String &streamURI, Track &track
 			if (!trackMode && !dataMode) albumInfo.year = year;
 		}
 
+		if (line.StartsWith("REM DISCNUMBER "))
+		{
+			Int	 disc = line.Tail(line.Length() - 15).ToInt();
+
+			if (!readInfoTags || preferCueSheets) info.disc = disc;
+
+			if (!trackMode && !dataMode) albumInfo.disc = disc;
+		}
+
 		if (line.StartsWith("REM COMMENT "))
 		{
 			String	 comment;


### PR DESCRIPTION
Every other REM metadata comment (GENRE, DATE, COMMENT, REPLAYGAIN_*)
was already recognized, but REM DISCNUMBER fell through to the
catch-all "skip other comments" case, leaving the disc number and
<disc> tag empty for cue-based rips.

Closes #687