### PR TITLE
Respect ClearAlbumArtist setting when reading cue sheets

### DIFF
--- a/components/decoder/cuesheet/cuesheet.cpp
+++ b/components/decoder/cuesheet/cuesheet.cpp
@@ -212,7 +212,7 @@ Error BoCA::DecoderCueSheet::GetStreamInfo(const String &streamURI, Track &track
 				info.artist = artist;
 
 				if (albumInfo.artist != NIL &&
-				    albumInfo.artist != artist) info.SetOtherInfo(INFO_ALBUMARTIST, albumInfo.artist);
+				    (albumInfo.artist != artist || !config->GetIntValue("TagEdit", "ClearAlbumArtist", False))) info.SetOtherInfo(INFO_ALBUMARTIST, albumInfo.artist);
 			}
 
 			if (!trackMode && !dataMode) albumInfo.artist = artist;


### PR DESCRIPTION
The cue sheet reader always withheld the album artist tag whenever it
matched the track artist, regardless of the TagEdit ClearAlbumArtist
setting, which is meant to make that behavior opt-in. Gate it on the
setting the same way the tag editor's album chooser already does.

Closes #559