### PR TITLE
Write back unrecognized user text tags in Vorbis comments

### DIFF
--- a/components/tagger/vorbis/vorbis.cpp
+++ b/components/tagger/vorbis/vorbis.cpp
@@ -183,6 +183,8 @@ Error BoCA::TaggerVorbis::RenderBuffer(Buffer<UnsignedByte> &buffer, const Track
 
 		else if	(key == INFO_MUSICBRAINZ_RELEASETYPE)	   { RenderTagItem("RELEASETYPE",		   value, buffer       ); numItems++; }
 		else if	(key == INFO_MUSICBRAINZ_RELEASESTATUS)	   { RenderTagItem("RELEASESTATUS",		   value, buffer       ); numItems++; }
+
+		else if	(key == INFO_USERTEXT)			   { RenderTagItem(value.Head(value.Find(":|:")), value.Tail(value.Length() - value.Find(":|:") - 3), buffer); numItems++; }
 	}
 
 	/* Save Replay Gain info.


### PR DESCRIPTION
Reading a Vorbis comment file already preserved any unrecognized field
as an INFO_USERTEXT entry, but writing had no matching case, so custom
tags (e.g. a URL field) were silently dropped whenever a file got
re-tagged or converted between Vorbis-comment-based formats. id3v2
already round-trips this correctly, this mirrors the same approach.

Closes #760